### PR TITLE
Robolectric 3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,14 +77,14 @@ class DatabaseRoboSpec extends FeatureSpec with Matchers with BeforeAndAfter wit
   var db: SQLiteDatabase = _
 
   override protected def beforeAll(): Unit = {
-    helper = new SQLiteOpenHelper(Robolectric.application, "test", null, 1) {
+    helper = new SQLiteOpenHelper(RuntimeEnvironment.application, "test", null, 1) {
       override def onUpgrade(db: SQLiteDatabase, oldVersion: Int, newVersion: Int): Unit = {}
       override def onCreate(db: SQLiteDatabase): Unit = {}
     }
   }
 
   override protected def afterAll(): Unit = {
-    Robolectric.application.getDatabasePath(helper.getDatabaseName).delete()
+    RuntimeEnvironment.application.getDatabasePath(helper.getDatabaseName).delete()
   }
 
   before {

--- a/build.sbt
+++ b/build.sbt
@@ -4,9 +4,9 @@ organization := "com.geteit"
 
 version := "0.7"
 
-scalaVersion := "2.11.4"
+scalaVersion := "2.11.6"
 
-crossScalaVersions := Seq("2.10.0", "2.11.4")
+crossScalaVersions := Seq("2.10.5", "2.11.6")
 
 resolvers ++= Seq(
   "Local Maven Repository" at "file://"+Path.userHome.absolutePath+"/.m2/repository",

--- a/build.sbt
+++ b/build.sbt
@@ -22,10 +22,10 @@ publishTo := {
 
 libraryDependencies ++= Seq(
   "org.robolectric" % "robolectric" % "2.4",
-  "org.robolectric" % "android-all" % "5.0.0_r2-robolectric-0" % "provided",
+  "org.robolectric" % "android-all" % "5.0.0_r2-robolectric-1" % "provided",
   "com.android.support" % "support-v4" % "19.0.0" % "provided",
-  "org.scalatest" %% "scalatest" % "2.1.6",
-  "junit" % "junit" % "4.8.2",
+  "org.scalatest" %% "scalatest" % "2.2.5",
+  "junit" % "junit" % "4.12",
   "org.apache.maven" % "maven-ant-tasks" % "2.1.3"
 )
 

--- a/build.sbt
+++ b/build.sbt
@@ -21,7 +21,7 @@ publishTo := {
 }
 
 libraryDependencies ++= Seq(
-  "org.robolectric" % "robolectric" % "2.4",
+  "org.robolectric" % "robolectric" % "3.0-rc3",
   "org.robolectric" % "android-all" % "5.0.0_r2-robolectric-1" % "provided",
   "com.android.support" % "support-v4" % "19.0.0" % "provided",
   "org.scalatest" %% "scalatest" % "2.2.5",

--- a/example/src/test/scala/org.robotest/OverrideSdkVersionSpec.scala
+++ b/example/src/test/scala/org.robotest/OverrideSdkVersionSpec.scala
@@ -11,7 +11,7 @@ class OverrideSdkVersionSpec extends FeatureSpec with Matchers with RobolectricS
   scenario("Use sdk version specified in config annotation") {
     Build.VERSION.SDK_INT shouldEqual Build.VERSION_CODES.JELLY_BEAN
 
-    val appManifest = Robolectric.shadowOf(Robolectric.application).getAppManifest
+    val appManifest = Shadows.shadowOf(RuntimeEnvironment.application).getAppManifest
     Build.VERSION.SDK_INT should not equal appManifest.getTargetSdkVersion
   }
 }

--- a/example/src/test/scala/org.robotest/ResourcesSpec.scala
+++ b/example/src/test/scala/org.robotest/ResourcesSpec.scala
@@ -8,6 +8,6 @@ import org.scalatest.{FeatureSpec, Matchers, RobolectricSuite}
 class ResourcesSpec extends FeatureSpec with Matchers with RobolectricSuite {
 
   scenario("Load string from android resources") {
-    Robolectric.application.getResources.getString(R.string.test_string) shouldEqual "test"
+    RuntimeEnvironment.application.getResources.getString(R.string.test_string) shouldEqual "test"
   }
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.7
+sbt.version=0.13.8

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,2 @@
 
-addSbtPlugin("com.hanhuy.sbt" %% "android-sdk-plugin" % "1.3.13")
+addSbtPlugin("com.hanhuy.sbt" %% "android-sdk-plugin" % "1.3.23")

--- a/src/main/scala/org/robolectric/internal/RoboTestUniverse.scala
+++ b/src/main/scala/org/robolectric/internal/RoboTestUniverse.scala
@@ -8,10 +8,14 @@ import android.content.pm.{ApplicationInfo, PackageManager}
 import android.content.res.{Configuration, Resources}
 import org.robolectric.Robolectric._
 import org.robolectric._
+import org.robolectric.internal.fakes.RoboInstrumentation
+import org.robolectric.manifest.AndroidManifest
 import org.robolectric.annotation.Config
-import org.robolectric.res.builder.RobolectricPackageManager
-import org.robolectric.res.{ResBunch, ResourceLoader}
+import org.robolectric.res.builder.{ RobolectricPackageManager, DefaultPackageManager }
+import org.robolectric.res.{ResBunch, ResourceLoader, ResBundle}
 import org.robolectric.shadows.{ShadowActivityThread, ShadowContextImpl, ShadowLog, ShadowResources}
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.util.ReflectionHelpers
 import org.scalatest.RoboSuiteRunner
 
 /**
@@ -22,7 +26,7 @@ class RoboTestUniverse(roboSuiteRunner: RoboSuiteRunner) extends ParallelUnivers
   private var sdkConfig: SdkConfig = null
 
   def resetStaticState(config: Config) {
-    Robolectric.reset(config)
+    Robolectric.reset()
     if (!loggingInitialized) {
       ShadowLog.setupLogging()
       loggingInitialized = true
@@ -34,20 +38,21 @@ class RoboTestUniverse(roboSuiteRunner: RoboSuiteRunner) extends ParallelUnivers
    * qualifier for the target api level (which comes from the manifest or Config.emulateSdk()).
    */
   private def addVersionQualifierToQualifiers(qualifiers: String): String =
-    ResBunch.getVersionQualifierApiLevel(qualifiers) match {
+    ResBundle.getVersionQualifierApiLevel(qualifiers) match {
       case -1 if qualifiers.length > 0 => qualifiers + "-v" + sdkConfig.getApiLevel
       case -1 => qualifiers + "v" + sdkConfig.getApiLevel
       case _ => qualifiers
     }
 
-  def setUpApplicationState(method: Method, testLifecycle: TestLifecycle[_], strictI18n: Boolean, systemResourceLoader: ResourceLoader, appManifest: AndroidManifest, config: Config) {
-    Robolectric.application = null
-    Robolectric.packageManager = new RobolectricPackageManager
-    Robolectric.packageManager.addPackage(DEFAULT_PACKAGE_NAME)
+  def setUpApplicationState(method: Method, testLifecycle: TestLifecycle[_], systemResourceLoader: ResourceLoader, appManifest: AndroidManifest, config: Config) {
+    RuntimeEnvironment.application = null
+    val packageManager = new DefaultPackageManager(Robolectric.getShadowsAdapter())
+    packageManager.addPackage(DEFAULT_PACKAGE_NAME)
     val resourceLoader = roboSuiteRunner.resourceLoader
     if (appManifest != null) {
-      Robolectric.packageManager.addManifest(appManifest, resourceLoader)
+      packageManager.addManifest(appManifest, resourceLoader)
     }
+    RuntimeEnvironment.setRobolectricPackageManager(packageManager)
     ShadowResources.setSystemResources(systemResourceLoader)
     val qualifiers: String = addVersionQualifierToQualifiers(config.qualifiers)
     val systemResources: Resources = Resources.getSystem
@@ -55,52 +60,51 @@ class RoboTestUniverse(roboSuiteRunner: RoboSuiteRunner) extends ParallelUnivers
     shadowOf(configuration).overrideQualifiers(qualifiers)
     systemResources.updateConfiguration(configuration, systemResources.getDisplayMetrics)
     shadowOf(systemResources.getAssets).setQualifiers(qualifiers)
-    val contextImplClass: Class[_] = ReflectionHelpers.loadClassReflectively(getClass.getClassLoader, ShadowContextImpl.CLASS_NAME)
-    val activityThreadClass: Class[_] = ReflectionHelpers.loadClassReflectively(getClass.getClassLoader, ShadowActivityThread.CLASS_NAME)
-    val activityThread: AnyRef = ReflectionHelpers.callConstructorReflectively(activityThreadClass)
-    Robolectric.activityThread = activityThread
-    ReflectionHelpers.setFieldReflectively(activityThread, "mInstrumentation", new RoboInstrumentation)
-    ReflectionHelpers.setFieldReflectively(activityThread, "mCompatConfiguration", configuration)
-    val systemContextImpl: Context = ReflectionHelpers.callStaticMethodReflectively(contextImplClass, "createSystemContext", new ReflectionHelpers.ClassParameter(activityThreadClass, activityThread))
+    val contextImplClass: Class[_] = ReflectionHelpers.loadClass(getClass.getClassLoader, ShadowContextImpl.CLASS_NAME)
+    val activityThreadClass: Class[_] = ReflectionHelpers.loadClass(getClass.getClassLoader, ShadowActivityThread.CLASS_NAME)
+    val activityThread: AnyRef = ReflectionHelpers.callConstructor(activityThreadClass.asInstanceOf[Class[AnyRef]])
+    RuntimeEnvironment.setActivityThread(activityThread)
+    ReflectionHelpers.setField(activityThread, "mInstrumentation", new RoboInstrumentation)
+    ReflectionHelpers.setField(activityThread, "mCompatConfiguration", configuration)
+    val systemContextImpl: Context = ReflectionHelpers.callStaticMethod(contextImplClass, "createSystemContext", new ReflectionHelpers.ClassParameter(activityThreadClass, activityThread))
     val application: Application = testLifecycle.createApplication(method, appManifest, config).asInstanceOf[Application]
     if (application != null) {
       var packageName: String = if (appManifest != null) appManifest.getPackageName else null
       if (packageName == null) packageName = DEFAULT_PACKAGE_NAME
       var applicationInfo: ApplicationInfo = null
       try {
-        applicationInfo = Robolectric.packageManager.getApplicationInfo(packageName, 0)
+        applicationInfo = RuntimeEnvironment.getPackageManager.getApplicationInfo(packageName, 0)
       }
       catch {
         case e: PackageManager.NameNotFoundException => {
           throw new RuntimeException(e)
         }
       }
-      val compatibilityInfoClass: Class[_] = ReflectionHelpers.loadClassReflectively(getClass.getClassLoader, "android.content.res.CompatibilityInfo")
-      val loadedApk: AnyRef = ReflectionHelpers.callInstanceMethodReflectively(activityThread, "getPackageInfo", new ReflectionHelpers.ClassParameter(classOf[ApplicationInfo], applicationInfo), new ReflectionHelpers.ClassParameter(compatibilityInfoClass, null), new ReflectionHelpers.ClassParameter(classOf[ClassLoader], getClass.getClassLoader), new ReflectionHelpers.ClassParameter(classOf[Boolean], false), new ReflectionHelpers.ClassParameter(classOf[Boolean], true))
+      val compatibilityInfoClass: Class[_] = ReflectionHelpers.loadClass(getClass.getClassLoader, "android.content.res.CompatibilityInfo")
+      val loadedApk: AnyRef = ReflectionHelpers.callInstanceMethod(activityThread, "getPackageInfo", new ReflectionHelpers.ClassParameter(classOf[ApplicationInfo], applicationInfo), new ReflectionHelpers.ClassParameter(compatibilityInfoClass, null), new ReflectionHelpers.ClassParameter(classOf[ClassLoader], getClass.getClassLoader), new ReflectionHelpers.ClassParameter(classOf[Boolean], false), new ReflectionHelpers.ClassParameter(classOf[Boolean], true))
       shadowOf(application).bind(appManifest, resourceLoader)
       if (appManifest == null) {
         shadowOf(application).setPackageName(applicationInfo.packageName)
       }
       val appResources: Resources = application.getResources
-      ReflectionHelpers.setFieldReflectively(loadedApk, "mResources", appResources)
-      val contextImpl: Context = ReflectionHelpers.callInstanceMethodReflectively(systemContextImpl, "createPackageContext", new ReflectionHelpers.ClassParameter(classOf[String], applicationInfo.packageName), new ReflectionHelpers.ClassParameter(classOf[Int], Context.CONTEXT_INCLUDE_CODE))
-      ReflectionHelpers.setFieldReflectively(activityThread, "mInitialApplication", application)
-      ReflectionHelpers.callInstanceMethodReflectively(application, "attach", new ReflectionHelpers.ClassParameter(classOf[Context], contextImpl))
+      ReflectionHelpers.setField(loadedApk, "mResources", appResources)
+      val contextImpl: Context = ReflectionHelpers.callInstanceMethod(systemContextImpl, "createPackageContext", new ReflectionHelpers.ClassParameter(classOf[String], applicationInfo.packageName), new ReflectionHelpers.ClassParameter(classOf[Int], Context.CONTEXT_INCLUDE_CODE))
+      ReflectionHelpers.setField(activityThread, "mInitialApplication", application)
+      ReflectionHelpers.callInstanceMethod(application, "attach", new ReflectionHelpers.ClassParameter(classOf[Context], contextImpl))
       appResources.updateConfiguration(configuration, appResources.getDisplayMetrics)
       shadowOf(appResources.getAssets).setQualifiers(qualifiers)
-      shadowOf(application).setStrictI18n(strictI18n)
-      Robolectric.application = application
+      RuntimeEnvironment.application = application
       application.onCreate()
     }
   }
 
   def tearDownApplication(): Unit = {
-    if (Robolectric.application != null) {
-      Robolectric.application.onTerminate()
+    if (RuntimeEnvironment.application != null) {
+      RuntimeEnvironment.application.onTerminate()
     }
   }
 
-  def getCurrentApplication = Robolectric.application
+  def getCurrentApplication = RuntimeEnvironment.application
 
   def setSdkConfig(sdkConfig: SdkConfig): Unit = {
     this.sdkConfig = sdkConfig

--- a/src/test/scala/org/robotest/DatabaseRoboSpec.scala
+++ b/src/test/scala/org/robotest/DatabaseRoboSpec.scala
@@ -2,6 +2,7 @@ package org.robotest
 
 import android.database.sqlite.{SQLiteDatabase, SQLiteOpenHelper}
 import org.robolectric.Robolectric
+import org.robolectric.RuntimeEnvironment
 import org.scalatest._
 import android.content.ContentValues
 
@@ -16,14 +17,14 @@ class DatabaseRoboSpec extends FeatureSpec with Matchers with BeforeAndAfter wit
   var db: SQLiteDatabase = _
 
   override protected def beforeAll(): Unit = {
-    helper = new SQLiteOpenHelper(Robolectric.application, "test", null, 1) {
+    helper = new SQLiteOpenHelper(RuntimeEnvironment.application, "test", null, 1) {
       override def onUpgrade(db: SQLiteDatabase, oldVersion: Int, newVersion: Int): Unit = {}
       override def onCreate(db: SQLiteDatabase): Unit = {}
     }
   }
 
   override protected def afterAll(): Unit = {
-    Robolectric.application.getDatabasePath(helper.getDatabaseName).delete()
+    RuntimeEnvironment.application.getDatabasePath(helper.getDatabaseName).delete()
   }
 
   before {


### PR DESCRIPTION
Hi @zbsz,

first of all, this branch is not yet ready to merge!

I tried to update robotest to robolectric 3.0-RC3 for Lollipop compatibility.
I don't know the project so my fixes were rather driven by compiler and robolectric git history.
The project compiles in this state, but the test throws a NullPointerException

```
[info]   java.lang.NullPointerException:
[info]   at org.scalatest.RoboSuiteRunner.<init>(RobolectricSuite.scala:78)
[info]   at org.scalatest.RobolectricSuite$class.runner(RobolectricSuite.scala:34)
```

probably caused by [this line](https://github.com/zbsz/robotest/compare/zbsz:master...nightscape:robolectric_3_0?expand=1#diff-4f20265e7de79cc1cce92000cb04a419R51).

It would be great if you could have a look at my changes and you might have a better idea how to fix the NPE in the tests.

Best
  Martin
