### PR TITLE
add implementation for specs2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name := "robotest"
 
 organization := "com.geteit"
 
-version := "0.12"
+version := "0.13-SNAPSHOT"
 
 scalaVersion := "2.11.7"
 
@@ -11,7 +11,8 @@ crossScalaVersions := Seq("2.10.5", "2.11.7")
 libraryDependencies ++= Seq(
   "org.robolectric" % "robolectric" % "3.0",
   "org.robolectric" % "android-all" % "5.0.0_r2-robolectric-1",
-  "org.scalatest" %% "scalatest" % "2.2.5",
+  "org.scalatest" %% "scalatest" % "2.2.5" % "provided",
+  "org.specs2" %% "specs2-core" % "3.6.5" % "provided",
   "junit" % "junit" % "4.12",
   "org.apache.maven" % "maven-ant-tasks" % "2.1.3"
 )

--- a/src/main/scala/org/robotest/RoboTest.scala
+++ b/src/main/scala/org/robotest/RoboTest.scala
@@ -1,0 +1,210 @@
+package robotest
+
+import java.io.File
+import java.lang.annotation.Annotation
+import java.lang.reflect
+import java.security.SecureRandom
+import java.util
+import java.util.Properties
+import java.lang.reflect.Constructor
+
+import android.os.Build
+import org.robolectric._
+import org.robolectric.annotation.Config
+import org.robolectric.internal._
+import org.robolectric.internal.bytecode._
+import org.robolectric.internal.dependency._
+import org.robolectric.manifest.AndroidManifest
+import org.robolectric.res._
+import org.robolectric.util.{Logger, ReflectionHelpers}
+
+import scala.collection.JavaConverters._
+import scala.util.Try
+
+trait RoboTest {
+  val skipInstrumentation: Seq[Class[_]] = Nil
+  val skipInstrumentationPkg: Seq[String] = Nil
+  val aarsDir = Fs.currentDirectory().join("target", "aars")
+  def robolectricShadows: Seq[Class[_]] = Nil
+}
+
+trait RoboSuiteRunner[A <: RoboTest] {
+  val suite: A
+
+  val suiteClass = suite.getClass
+  val skipInstrumentation = suite.skipInstrumentation
+  val skipInstrumentationPkg = suite.skipInstrumentationPkg
+  val shadows = suite.robolectricShadows
+  val aarsDir = suite.aarsDir
+
+  lazy val roboInstance = {
+    classLoader.loadClass(suiteClass.getName)
+      .newInstance.asInstanceOf[A]
+  }
+
+  lazy val config: Config = {
+
+    val configProperties: Properties =
+      Option(suiteClass.getClassLoader.getResourceAsStream("robolectric.properties")) .map { resourceAsStream =>
+        try {
+          val properties = new Properties
+          properties.load(resourceAsStream)
+          properties
+        } finally { resourceAsStream.close() }
+      } .orNull
+
+    def classConfigs(cls: Class[_], acc: List[Config] = Nil): List[Config] = cls match {
+      case null => acc
+      case _ => classConfigs(cls.getSuperclass, cls.getAnnotation(classOf[Config]) :: acc)
+    }
+
+    (RoboSuiteRunner.defaultsFor(classOf[Config])
+      :: Config.Implementation.fromProperties(configProperties)
+      :: classConfigs(suiteClass)
+    )reduceLeft { (config, opt) =>
+      Option(opt).fold(config)(new Config.Implementation(config, _))
+    }
+  }
+
+  lazy val appManifest: AndroidManifest = {
+    def libraryDirs(baseDir: FsFile) = config.libraries().map(baseDir.join(_)).toSeq
+
+    def createAppManifest(manifestFile: FsFile, resDir: FsFile, assetsDir: FsFile): AndroidManifest = {
+      if (manifestFile.exists) {
+        val manifest = new AndroidManifest(manifestFile, resDir, assetsDir) {
+          override def findLibraries(): util.List[FsFile] = {
+            val aars = if (aarsDir.isDirectory) aarsDir.listFiles().filter(d => d.isDirectory && d.listFiles().nonEmpty).toList else Nil
+            (aars ++ super.findLibraries().asScala).distinct.asJava
+          }
+        }
+        manifest.setPackageName(System.getProperty("android.package"))
+        if (config.libraries().nonEmpty) {
+          manifest.setLibraryDirectories(libraryDirs(manifestFile.getParent).asJava)
+        }
+        manifest
+      } else {
+        System.out.print("WARNING: No manifest file found at " + manifestFile.getPath + ".")
+        System.out.println("Falling back to the Android OS resources only.")
+        System.out.println("To remove this warning, annotate your test class with @Config(manifest=Config.NONE).")
+        null
+      }
+    }
+
+    if (config.manifest == Config.NONE) null
+    else {
+      val manifestProperty = System.getProperty("android.manifest")
+      val resourcesProperty = System.getProperty("android.resources")
+      val assetsProperty = System.getProperty("android.assets")
+      val defaultManifest = config.manifest == Config.DEFAULT
+      if (defaultManifest && manifestProperty != null) {
+        createAppManifest(Fs.fileFromPath(manifestProperty), Fs.fileFromPath(resourcesProperty), Fs.fileFromPath(assetsProperty))
+      } else {
+        val manifestFile = {
+          val file = Fs.currentDirectory().join(if (defaultManifest) AndroidManifest.DEFAULT_MANIFEST_NAME else config.manifest)
+          if (file.exists() || !defaultManifest) file
+          else Fs.currentDirectory().join("src", "main", AndroidManifest.DEFAULT_MANIFEST_NAME)
+        }
+        val baseDir = manifestFile.getParent
+        createAppManifest(manifestFile, baseDir.join(config.resourceDir), baseDir.join(Config.DEFAULT_ASSET_FOLDER))
+      }
+    }
+  }
+
+  lazy val sdkVersion = {
+    require(config.sdk.length <= 1, s"RoboTest does not support multiple values for @Config.sdk")
+    if (config.sdk.nonEmpty && config.sdk.head != -1) config.sdk.head
+    else Option(appManifest).fold(SdkConfig.FALLBACK_SDK_VERSION)(_.getTargetSdkVersion)
+  }
+
+  lazy val jarResolver =
+    if (System.getProperty("robolectric.offline") != "true") {
+      val cacheDir = new File(new File(System.getProperty("java.io.tmpdir")), "robolectric")
+      cacheDir.mkdirs
+      if (cacheDir.exists) {
+        Logger.info("Dependency cache location: %s", cacheDir.getAbsolutePath)
+        new CachedDependencyResolver(new MavenDependencyResolver, cacheDir, 60 * 60 * 24 * 1000)
+      } else new MavenDependencyResolver
+    } else new LocalDependencyResolver(new File(System.getProperty("robolectric.dependency.dir", ".")))
+
+  lazy val classLoaderConfig = {
+    val builder = InstrumentationConfiguration.newBuilder()
+    builder.doNotAquireClass(getClass.getName)
+    builder.doNotAquirePackage("robotest")
+    builder.doNotAquirePackage("org.specs2")
+    builder.doNotAquirePackage("org.scalatest")
+    builder.doNotAquirePackage("org.scalactic")
+    skipInstrumentation foreach { cls => builder.doNotAquireClass(cls.getName) }
+    skipInstrumentationPkg foreach builder.doNotAquirePackage
+    builder.build()
+  }
+
+  lazy val sdkEnvironment = {
+    val env = new InstrumentingClassLoaderFactory(classLoaderConfig, jarResolver).getSdkEnvironment(new SdkConfig(sdkVersion))
+
+    val shadowMap = {
+      val builder = new ShadowMap.Builder()
+      config.shadows() foreach builder.addShadowClass
+      shadows foreach builder.addShadowClass
+      builder.build()
+    }
+
+    val classHandler = new ShadowWrangler(shadowMap)
+
+    val robolectricInternalsClass = ReflectionHelpers.loadClass(env.getRobolectricClassLoader, classOf[RobolectricInternals].getName)
+    ReflectionHelpers.setStaticField(robolectricInternalsClass, "classHandler", classHandler)
+    ReflectionHelpers.setStaticField(env.bootstrappedClass(classOf[Build.VERSION]), "SDK_INT", sdkVersion)
+
+    env
+  }
+
+  lazy val systemResourceLoader = sdkEnvironment.getSystemResourceLoader(jarResolver)
+
+  lazy val appResourceLoader = Option(appManifest) map { manifest =>
+    val appAndLibraryResourceLoaders = manifest.getIncludedResourcePaths.asScala.map(new PackageResourceLoader(_))
+    val overlayResourceLoader = new OverlayResourceLoader(manifest.getPackageName, appAndLibraryResourceLoaders.asJava)
+    val resourceLoaders = Map(
+      "android" -> systemResourceLoader,
+      manifest.getPackageName -> overlayResourceLoader
+    )
+    new RoutingResourceLoader(resourceLoaders.asJava)
+  }
+
+  lazy val classLoader = sdkEnvironment.getRobolectricClassLoader
+
+  lazy val resourceLoader = appResourceLoader.getOrElse(systemResourceLoader)
+
+  lazy val parallelUniverse =
+    sdkEnvironment.getRobolectricClassLoader
+      .loadClass(classOf[RoboTestUniverse].getName)
+      .asSubclass(classOf[ParallelUniverseInterface])
+      .getConstructor(classOf[ResourceLoader])
+      .newInstance(resourceLoader)
+
+  def setup() = {
+    Thread.currentThread.setContextClassLoader(sdkEnvironment.getRobolectricClassLoader)
+
+    parallelUniverse.resetStaticState(config)
+    parallelUniverse.setSdkConfig(sdkEnvironment.getSdkConfig)
+
+    val testLifecycle = classLoader.loadClass(classOf[DefaultTestLifecycle].getName).newInstance.asInstanceOf[TestLifecycle[_]]
+    parallelUniverse.setUpApplicationState(null, testLifecycle, systemResourceLoader, appManifest, config)
+
+    Try(resourceLoader.getRawValue(null)) // force resources loading
+  }
+
+  def teardown() = {
+    parallelUniverse.tearDownApplication()
+    parallelUniverse.resetStaticState(config)
+    Thread.currentThread.setContextClassLoader(suiteClass.getClassLoader)
+  }
+}
+
+object RoboSuiteRunner {
+  new SecureRandom() // this starts up the Poller SunPKCS11-Darwin thread early, outside of any Robolectric classloader
+
+  private def defaultsFor[A <: Annotation](annotation: Class[A]): A = {
+    annotation.cast(reflect.Proxy.newProxyInstance(annotation.getClassLoader, Array[Class[_]](annotation), new reflect.InvocationHandler() {
+      override def invoke(proxy: AnyRef, method: reflect.Method, args: Array[AnyRef]): AnyRef = method.getDefaultValue
+    }))
+  }
+}

--- a/src/main/scala/org/scalatest/RobolectricSuite.scala
+++ b/src/main/scala/org/scalatest/RobolectricSuite.scala
@@ -1,13 +1,5 @@
 package org.scalatest
 
-import java.io.File
-import java.lang.annotation.Annotation
-import java.lang.reflect
-import java.security.SecureRandom
-import java.util
-import java.util.Properties
-
-import android.os.Build
 import org.robolectric._
 import org.robolectric.annotation.Config
 import org.robolectric.internal._
@@ -28,192 +20,24 @@ import scala.util.Try
  * - loads current suite in Robolectric loader
  * - executes tests in shadowed suite
  */
-trait RobolectricSuite extends SuiteMixin { self: Suite =>
-
-  val skipInstrumentation: Seq[Class[_]] = Nil
-  val skipInstrumentationPkg: Seq[String] = Nil
-  val aarsDir = Fs.currentDirectory().join("target", "aars")
-
-  def robolectricShadows: Seq[Class[_]] = Nil
+trait RobolectricSuite extends SuiteMixin with robotest.RoboTest { self: Suite =>
 
   lazy val runner = new RoboSuiteRunner(this)
 
-  abstract override def run(testName: Option[String], args: Args): Status = runner.run(testName, args)
+  abstract override def run(testName: Option[String], args: Args): Status =
+    runner.run(testName, args)
 
-  def runShadow(testName: Option[String], args: Args): Status = super.run(testName, args)
+  def runShadow(testName: Option[String], args: Args): Status =
+    super.run(testName, args)
 }
 
-class RoboSuiteRunner(suite: RobolectricSuite) { runner =>
-
-  val suiteClass = suite.getClass
-  val skipInstrumentation = suite.skipInstrumentation
-  val skipInstrumentationPkg = suite.skipInstrumentationPkg
-  val shadows = suite.robolectricShadows
-  val aarsDir = suite.aarsDir
-
-  lazy val config: Config = {
-
-    val configProperties: Properties =
-      Option(suiteClass.getClassLoader.getResourceAsStream("robolectric.properties")) .map { resourceAsStream =>
-        try {
-          val properties = new Properties
-          properties.load(resourceAsStream)
-          properties
-        } finally { resourceAsStream.close() }
-      } .orNull
-
-    def classConfigs(cls: Class[_], acc: List[Config] = Nil): List[Config] = cls match {
-      case null => acc
-      case _ => classConfigs(cls.getSuperclass, cls.getAnnotation(classOf[Config]) :: acc)
-    }
-
-    (RoboSuiteRunner.defaultsFor(classOf[Config])
-      :: Config.Implementation.fromProperties(configProperties)
-      :: classConfigs(suiteClass)
-    )reduceLeft { (config, opt) =>
-      Option(opt).fold(config)(new Config.Implementation(config, _))
-    }
-  }
-
-  lazy val appManifest: AndroidManifest = {
-    def libraryDirs(baseDir: FsFile) = config.libraries().map(baseDir.join(_)).toSeq
-
-    def createAppManifest(manifestFile: FsFile, resDir: FsFile, assetsDir: FsFile): AndroidManifest = {
-      if (manifestFile.exists) {
-        val manifest = new AndroidManifest(manifestFile, resDir, assetsDir) {
-          override def findLibraries(): util.List[FsFile] = {
-            val aars = if (aarsDir.isDirectory) aarsDir.listFiles().filter(d => d.isDirectory && d.listFiles().nonEmpty).toList else Nil
-            (aars ++ super.findLibraries().asScala).distinct.asJava
-          }
-        }
-        manifest.setPackageName(System.getProperty("android.package"))
-        if (config.libraries().nonEmpty) {
-          manifest.setLibraryDirectories(libraryDirs(manifestFile.getParent).asJava)
-        }
-        manifest
-      } else {
-        System.out.print("WARNING: No manifest file found at " + manifestFile.getPath + ".")
-        System.out.println("Falling back to the Android OS resources only.")
-        System.out.println("To remove this warning, annotate your test class with @Config(manifest=Config.NONE).")
-        null
-      }
-    }
-
-    if (config.manifest == Config.NONE) null
-    else {
-      val manifestProperty = System.getProperty("android.manifest")
-      val resourcesProperty = System.getProperty("android.resources")
-      val assetsProperty = System.getProperty("android.assets")
-      val defaultManifest = config.manifest == Config.DEFAULT
-      if (defaultManifest && manifestProperty != null) {
-        createAppManifest(Fs.fileFromPath(manifestProperty), Fs.fileFromPath(resourcesProperty), Fs.fileFromPath(assetsProperty))
-      } else {
-        val manifestFile = {
-          val file = Fs.currentDirectory().join(if (defaultManifest) AndroidManifest.DEFAULT_MANIFEST_NAME else config.manifest)
-          if (file.exists() || !defaultManifest) file
-          else Fs.currentDirectory().join("src", "main", AndroidManifest.DEFAULT_MANIFEST_NAME)
-        }
-        val baseDir = manifestFile.getParent
-        createAppManifest(manifestFile, baseDir.join(config.resourceDir), baseDir.join(Config.DEFAULT_ASSET_FOLDER))
-      }
-    }
-  }
-
-  lazy val sdkVersion = {
-    require(config.sdk.length <= 1, s"RobolectricSuite does not support multiple values for @Config.sdk")
-    if (config.sdk.nonEmpty && config.sdk.head != -1) config.sdk.head
-    else Option(appManifest).fold(SdkConfig.FALLBACK_SDK_VERSION)(_.getTargetSdkVersion)
-  }
-
-  lazy val jarResolver =
-    if (System.getProperty("robolectric.offline") != "true") {
-      val cacheDir = new File(new File(System.getProperty("java.io.tmpdir")), "robolectric")
-      cacheDir.mkdirs
-      if (cacheDir.exists) {
-        Logger.info("Dependency cache location: %s", cacheDir.getAbsolutePath)
-        new CachedDependencyResolver(new MavenDependencyResolver, cacheDir, 60 * 60 * 24 * 1000)
-      } else new MavenDependencyResolver
-    } else new LocalDependencyResolver(new File(System.getProperty("robolectric.dependency.dir", ".")))
-
-  lazy val classLoaderConfig = {
-    val builder = InstrumentationConfiguration.newBuilder()
-    builder.doNotAquireClass(classOf[RoboSuiteRunner].getName)
-    builder.doNotAquirePackage("org.scalatest")
-    builder.doNotAquirePackage("org.scalactic")
-    skipInstrumentation foreach { cls => builder.doNotAquireClass(cls.getName) }
-    skipInstrumentationPkg foreach builder.doNotAquirePackage
-    builder.build()
-  }
-
-  lazy val sdkEnvironment = {
-    val env = new InstrumentingClassLoaderFactory(classLoaderConfig, jarResolver).getSdkEnvironment(new SdkConfig(sdkVersion))
-
-    val shadowMap = {
-      val builder = new ShadowMap.Builder()
-      config.shadows() foreach builder.addShadowClass
-      shadows foreach builder.addShadowClass
-      builder.build()
-    }
-
-    val classHandler = new ShadowWrangler(shadowMap)
-
-    val robolectricInternalsClass = ReflectionHelpers.loadClass(env.getRobolectricClassLoader, classOf[RobolectricInternals].getName)
-    ReflectionHelpers.setStaticField(robolectricInternalsClass, "classHandler", classHandler)
-    ReflectionHelpers.setStaticField(env.bootstrappedClass(classOf[Build.VERSION]), "SDK_INT", sdkVersion)
-
-    env
-  }
-  
-  lazy val systemResourceLoader = sdkEnvironment.getSystemResourceLoader(jarResolver)
-
-  lazy val appResourceLoader = Option(appManifest) map { manifest =>
-    val appAndLibraryResourceLoaders = manifest.getIncludedResourcePaths.asScala.map(new PackageResourceLoader(_))
-    val overlayResourceLoader = new OverlayResourceLoader(manifest.getPackageName, appAndLibraryResourceLoaders.asJava)
-    val resourceLoaders = Map(
-      "android" -> systemResourceLoader,
-      manifest.getPackageName -> overlayResourceLoader
-    )
-    new RoutingResourceLoader(resourceLoaders.asJava)
-  }
-  
-  lazy val classLoader = sdkEnvironment.getRobolectricClassLoader
-
-  lazy val resourceLoader = appResourceLoader.getOrElse(systemResourceLoader)
-
-  lazy val parallelUniverse =
-    sdkEnvironment.getRobolectricClassLoader
-      .loadClass(classOf[RoboTestUniverse].getName)
-      .asSubclass(classOf[ParallelUniverseInterface])
-      .getConstructor(classOf[ResourceLoader])
-      .newInstance(resourceLoader)
-
+class RoboSuiteRunner(val suite: RobolectricSuite) extends robotest.RoboSuiteRunner[RobolectricSuite] { runner =>
   def run(testName: Option[String], args: Args): Status = {
-    Thread.currentThread.setContextClassLoader(sdkEnvironment.getRobolectricClassLoader)
-
-    parallelUniverse.resetStaticState(config)
-    parallelUniverse.setSdkConfig(sdkEnvironment.getSdkConfig)
-
-    val testLifecycle = classLoader.loadClass(classOf[DefaultTestLifecycle].getName).newInstance.asInstanceOf[TestLifecycle[_]]
-    parallelUniverse.setUpApplicationState(null, testLifecycle, systemResourceLoader, appManifest, config)
-
     try {
-      Try(resourceLoader.getRawValue(null)) // force resources loading
-      val shadowSuite = classLoader.loadClass(suiteClass.getName).newInstance.asInstanceOf[RobolectricSuite]
-      shadowSuite.runShadow(testName, args)
+      setup()
+      roboInstance.runShadow(testName, args)
     } finally {
-      parallelUniverse.tearDownApplication()
-      parallelUniverse.resetStaticState(config)
-      Thread.currentThread.setContextClassLoader(classOf[RobolectricSuite].getClassLoader)
+      teardown()
     }
-  }
-}
-
-object RoboSuiteRunner {
-  new SecureRandom() // this starts up the Poller SunPKCS11-Darwin thread early, outside of any Robolectric classloader
-
-  private def defaultsFor[A <: Annotation](annotation: Class[A]): A = {
-    annotation.cast(reflect.Proxy.newProxyInstance(annotation.getClassLoader, Array[Class[_]](annotation), new reflect.InvocationHandler() {
-      override def invoke(proxy: AnyRef, method: reflect.Method, args: Array[AnyRef]): AnyRef = method.getDefaultValue
-    }))
   }
 }

--- a/src/main/scala/org/specs2/RobolectricSpecification.scala
+++ b/src/main/scala/org/specs2/RobolectricSpecification.scala
@@ -1,0 +1,20 @@
+package org.specs2
+
+import specification._
+import core.Env
+
+abstract class RobolectricSpecification
+extends Specification
+with robotest.RoboTest
+{
+  lazy val runner = new RoboSuiteRunner(this)
+
+  override def structure = (env: Env) => {
+    runner.setup()
+    runner.roboInstance.structureShadow(env)
+  }
+
+  def structureShadow = super.structure
+}
+
+class RoboSuiteRunner(val suite: RobolectricSpecification) extends robotest.RoboSuiteRunner[RobolectricSpecification]

--- a/src/main/scala/org/specs2/RobolectricSpecification.scala
+++ b/src/main/scala/org/specs2/RobolectricSpecification.scala
@@ -5,13 +5,20 @@ import core.Env
 
 abstract class RobolectricSpecification
 extends Specification
+with BeforeAfterAll
 with robotest.RoboTest
 {
-  lazy val runner = new RoboSuiteRunner(this)
+  var runner = new RoboSuiteRunner(this)
 
   override def structure = (env: Env) => {
     runner.setup()
-    runner.roboInstance.structureShadow(env)
+    val i = runner.roboInstance
+    i.runner = runner
+    i.structureShadow(env)
+  }
+
+  def afterAll() = {
+    runner.teardown()
   }
 
   def structureShadow = super.structure

--- a/src/main/scala/org/specs2/RobolectricSpecification.scala
+++ b/src/main/scala/org/specs2/RobolectricSpecification.scala
@@ -5,7 +5,7 @@ import core.Env
 
 abstract class RobolectricSpecification
 extends Specification
-with BeforeAfterAll
+with AfterAll
 with robotest.RoboTest
 {
   var runner = new RoboSuiteRunner(this)

--- a/src/test/scala/org/robotest/specs2/DatabaseRoboSpec.scala
+++ b/src/test/scala/org/robotest/specs2/DatabaseRoboSpec.scala
@@ -1,0 +1,59 @@
+package org.robotest
+package specs2
+
+import android.database.sqlite.{SQLiteDatabase, SQLiteOpenHelper}
+import org.robolectric.Robolectric
+import org.robolectric.RuntimeEnvironment
+import android.content.ContentValues
+import org.specs2._, matcher._, specification._
+
+/**
+ * Sample test using android database api.
+ * - uses singe database for all tests
+ * - creates test table before each test and drops it after
+  */
+class DatabaseRoboSpec extends RobolectricSpecification with MustMatchers with BeforeAfterEach with BeforeAfterAll {
+
+  var helper: SQLiteOpenHelper = _
+  var db: SQLiteDatabase = _
+
+  def beforeAll(): Unit = {
+    helper = new SQLiteOpenHelper(RuntimeEnvironment.application, "test", null, 1) {
+      override def onUpgrade(db: SQLiteDatabase, oldVersion: Int, newVersion: Int): Unit = {}
+      override def onCreate(db: SQLiteDatabase): Unit = {}
+    }
+  }
+
+  def afterAll(): Unit = {
+    RuntimeEnvironment.application.getDatabasePath(helper.getDatabaseName).delete()
+  }
+
+  def before = {
+    db = helper.getWritableDatabase
+    db.execSQL("CREATE TABLE Test(_id INTEGER PRIMARY KEY, value TEXT);")
+  }
+
+  def after = {
+    db.execSQL("DROP TABLE IF EXISTS Test;")
+    db.close()
+  }
+
+  def is = s2"""
+  Robolectric test using database
+  Insert row $insert
+  Query all rows from empty table $query
+  """
+
+  def insert = {
+    val values = new ContentValues()
+    values.put("_id", Integer.valueOf(1))
+    values.put("value", "test")
+
+    db.insert("Test", null, values) must_== 1
+  }
+
+  def query = {
+    val cursor = db.query("Test", null, null, null, null, null, null)
+    cursor.moveToFirst() must beFalse and (cursor.getCount must_== 0)
+  }
+}

--- a/src/test/scala/org/robotest/specs2/DatabaseRoboSpec.scala
+++ b/src/test/scala/org/robotest/specs2/DatabaseRoboSpec.scala
@@ -12,7 +12,11 @@ import org.specs2._, matcher._, specification._
  * - uses singe database for all tests
  * - creates test table before each test and drops it after
   */
-trait DatabaseRoboSpec extends RobolectricSpecification with MustMatchers {
+trait DatabaseRoboSpec
+extends RobolectricSpecification
+with MustMatchers
+with BeforeAll
+{
   lazy val helper: SQLiteOpenHelper = new SQLiteOpenHelper(RuntimeEnvironment.application, "test", null, 1) {
       override def onUpgrade(db: SQLiteDatabase, oldVersion: Int, newVersion: Int): Unit = {}
       override def onCreate(db: SQLiteDatabase): Unit = {}


### PR DESCRIPTION
hey there, this is a tentative solution for specs2; due to the convoluted nature of the execution model, this proves pretty difficult – consequently, there is no teardown at the end of a spec. The only solution I came up with for that was an override of the whole sbt test framework with a lot of duplicate code, which is pretty much undesirable. Anyway, this works so far. I don't know if you'll want this mixed in one project, so feel free to restructure.

I encountered a problem I couldn't resolve, maybe you can provide some insight here: with specs2, nested fragments are handled incorrectly. I.e. it seems that at some point, the regular fragment manager is delegated to instead of the child fragment manager, resulting in an invalid state error in `FragmentManager.executePendingTransactions`.
It's quite curious that it wouldn't happen in an identical test using the scalatest variant, so I assume it's an initialization problem. Do you think it's possible that the wrong android version is used at some point? the nested fragment problem is more serious in earlier versions iirc, I had that problem before in Robolectric and solved it somehow, but don't remember how.
